### PR TITLE
feat: swapoff before kubelet start

### DIFF
--- a/roles/prepare/kubernetes/templates/kubelet.service.j2
+++ b/roles/prepare/kubernetes/templates/kubelet.service.j2
@@ -3,6 +3,7 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/
 
 [Service]
+ExecStartPre=/usr/sbin/swapoff -a
 ExecStart={{ bin_dir }}/kubelet
 Restart=always
 StartLimitInterval=0


### PR DESCRIPTION
swap may be not be defined in fstab.

1. according to https://wiki.archlinux.org/title/Systemd#GPT_partition_automounting, there is another ways to define swap instead of fstab. On a GPT partitioned disk systemd-gpt-auto-generator(8) will mount partitions following the Discoverable Partitions Specification, thus they can be omitted from fstab.

2. systemd-fstab-generator read fstab to generate units, including a unit for swap. but this not means we can not write our [Mount] type Unit.