### PR TITLE
fix: reset node but leave /etc/sysconfig/kubelet file

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -162,6 +162,7 @@
   - "/etc/kubernetes"
   - "/var/lib/kubelet"
   - "/var/run/kubelet"
+  - "/etc/sysconfig/kubelet"
   - "/usr/lib/systemd/system/kubelet.service"
   - "/usr/lib/systemd/system/kubelet.service.d/"
   - "/usr/share/bash-completion/completions/kubectl"


### PR DESCRIPTION
fix: reset node but leave /etc/sysconfig/kubelet file

Closes #11